### PR TITLE
header img alt, link it to this-week wiki page

### DIFF
--- a/html-wrapper.php
+++ b/html-wrapper.php
@@ -19,7 +19,7 @@
 <link rel="webmention" href="https://webmention.io/indiewebcamp/webmention">
 </head>
 <body>
-<img src="/this-week/images/this-week-header.png" style="width:100%;">
+<a href="https://indieweb.org/this-week-in-the-indieweb"><img src="/this-week/images/this-week-header.png" style="width:100%;" alt="This Week in the IndieWeb" /></a>
 <main class="e-content">
 <?php
 	echo $html;


### PR DESCRIPTION
add alt to the header img, link header image to the this-week main page for easier discovery and navigation to archives and how to subscribe / follow (e.g. in case you got this in email)