### PR TITLE
join_with_and support serial comma

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -128,10 +128,13 @@ function join_with_and($array) {
 	
 	if(count($array) == 1)
 	  return array_pop($array);
-	
+
+	if(count($array) == 2)
+	  return implode(' and ', $array);
+
 	$last = array_pop($array);
 	
-	return implode(', ', $array) . ' and ' . $last;
+	return implode(', ', $array) . ', and ' . $last;
 }
 
 function e($text) {


### PR DESCRIPTION
fixed join_with_and to handle both two item array ' and ', and more than item array with a serial (Oxford) comma